### PR TITLE
Don't downgrade gcc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 Change log
 -----------
 
+* No longer force an older GCC version [Michal]
 * Update the resin-yocto-scripts submodule [Florin]
 * Update resin-yocto-scripts to allow external meta-resin builds [Will]
 * Update resin-yocto-scripts [Will]

--- a/layers/meta-resin-odroid/conf/layer.conf
+++ b/layers/meta-resin-odroid/conf/layer.conf
@@ -6,9 +6,3 @@ BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
 BBFILE_COLLECTIONS += "resin-odroid"
 BBFILE_PATTERN_resin-odroid := "^${LAYERDIR}/"
 BBFILE_PRIORITY_resin-odroid = "1337"
-
-# Downgrade GCC 5.2 -> 4.9.3
-# Because current u-boot revision does not have support for GCC 5
-# Reported at: https://github.com/hardkernel/u-boot/issues/20
-GCCVERSION = "4.9%"
-SDKGCCVERSION = "4.9%"


### PR DESCRIPTION
This is no longer necessary, and is generating some warnings on Morty.