### PR TITLE
linux-odroid: Fix build with stack protector

### DIFF
--- a/layers/meta-resin-odroid/recipes-kernel/linux/linux-odroid/stack_protector.patch
+++ b/layers/meta-resin-odroid/recipes-kernel/linux/linux-odroid/stack_protector.patch
@@ -1,0 +1,41 @@
+Define stack protector symbols in compressed boot object.
+
+This is taken from upstream commit 8779657d29c0ebcc0c94ede4df2f497baf1b563f.
+
+Signed-off-by: Kees Cook <keescook@chromium.org>
+Upstream-Status: Backport
+diff --git a/arch/arm/boot/compressed/misc.c b/arch/arm/boot/compressed/misc.c
+index 31bd43b82095..d4f891f56996 100644
+--- a/arch/arm/boot/compressed/misc.c
++++ b/arch/arm/boot/compressed/misc.c
+@@ -127,6 +127,18 @@ asmlinkage void __div0(void)
+ 	error("Attempting division by 0!");
+ }
+ 
++unsigned long __stack_chk_guard;
++
++void __stack_chk_guard_setup(void)
++{
++	__stack_chk_guard = 0x000a0dff;
++}
++
++void __stack_chk_fail(void)
++{
++	error("stack-protector: Kernel stack is corrupted\n");
++}
++
+ extern int do_decompress(u8 *input, int len, u8 *output, void (*error)(char *x));
+ 
+ 
+@@ -137,6 +149,8 @@ decompress_kernel(unsigned long output_start, unsigned long free_mem_ptr_p,
+ {
+ 	int ret;
+ 
++	__stack_chk_guard_setup();
++
+ 	output_data		= (unsigned char *)output_start;
+ 	free_mem_ptr		= free_mem_ptr_p;
+ 	free_mem_end_ptr	= free_mem_ptr_end_p;
+-- 
+2.13.5
+

--- a/layers/meta-resin-odroid/recipes-kernel/linux/linux-odroid_3.10.bbappend
+++ b/layers/meta-resin-odroid/recipes-kernel/linux/linux-odroid_3.10.bbappend
@@ -13,3 +13,8 @@
 # 'SRCREV'] (possible key names are git://github.com/hardkernel/linux.git;branch=master,
 # or use a ;rev=X URL parameter)
 COMPATIBLE_MACHINE = "odroid-ux3"
+
+FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
+
+SRC_URI += "file://stack_protector.patch"
+


### PR DESCRIPTION
Add some symbols required by stack protector in the compressed
boot object. This should allow enabling stack protector across
all Resin kernels.

Change-type: patch
Changelog-entry: Fix linux-odroid build with stack protector
Signed-off-by: Will Newton <willn@resin.io>