### PR TITLE
Update meta-rust to morty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 Change log
 -----------
 
+* Update meta-rust to morty [Will]
 * Include meta-rust layer [Will]
 * Add meta-rust layer [Will]
 


### PR DESCRIPTION

The morty branch of meta-rust contains a number of changes we need, so even though this BSP is jethro-based update meta-rust to morty.