### PR TITLE
local.conf.sample: Fix serial console for Odroid C1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 Change log
 -----------
 
+* Fix serial console for Odroid C1 [Florin]
+
 # v2.14.0+rev1
 ## (2018-07-18)
 

--- a/layers/meta-resin-odroid/conf/samples/local.conf.sample
+++ b/layers/meta-resin-odroid/conf/samples/local.conf.sample
@@ -5,6 +5,8 @@
 # We use the overlayfs docker storage driver on the Odroid XU4
 BALENA_STORAGE_odroid-xu4 = "overlay2"
 
+SERIAL_CONSOLE_odroid-c1 = "115200 ttyS0"
+
 # More info meta-resin/README.md
 #TARGET_REPOSITORY ?= ""
 #TARGET_TAG ?= ""


### PR DESCRIPTION
The correct console to be used with the current BSP is ttyS0.
The BSP layer still uses the old ttyAML0 which is not the correct one

Signed-off-by: Florin Sarbu <florin@resin.io>